### PR TITLE
Pass a config to override the default min words length and max keywords return setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ var extract = require('auto-keywords');
 
 var keywords = extract('your text here');
 ```
+
+var keywords = extract('your text here') , { minWordLength : 2, maxNumOfKeywords: 20};
+
+by default, keywords has to be more then 3 letters and maxmium of number of returned keywords is 10.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ var extract = require('auto-keywords');
 var keywords = extract('your text here');
 ```
 
-var keywords = extract('your text here') , { minWordLength : 2, maxNumOfKeywords: 20};
-
+to pass a configuration to override the settings, you can:
+```
+var keywords = extract('your text here', { minWordLength : 2, maxNumOfKeywords: 20});
+```
 by default, keywords has to be more then 3 letters and maxmium of number of returned keywords is 10.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-function extract(content) {
+function extract(content, config) {
   'use strict';
 
   var stops = ['able', 'about', 'above', 'act', 'add', 'afraid', 'after', 'again', 'against', 'age', 'ago', 'agree', 'all', 'almost', 'alone', 'along', 'already', 'also', 'although', 'always', 'am', 'amount', 'an', 'and', 'anger', 'angry', 'animal', 'another', 'answer', 'any', 'appear', 'apple', 'are', 'arrive', 'arm', 'arms', 'around', 'arrive', 'as', 'ask', 'at', 'attempt', 'aunt', 'away', 'back', 'bad', 'bag', 'bay', 'be', 'became', 'because', 'become', 'been', 'before', 'began', 'begin', 'behind', 'being', 'bell', 'belong', 'below', 'beside', 'best', 'better', 'between', 'beyond', 'big', 'body', 'bone', 'born', 'borrow', 'both', 'bottom', 'box', 'boy', 'break', 'bring', 'brought', 'bug', 'built', 'busy', 'but', 'buy', 'by', 'call', 'came', 'can', 'cause', 'choose', 'close', 'close', 'consider', 'come', 'consider', 'considerable', 'contain', 'continue', 'could', 'cry', 'cut', 'dare', 'dark', 'deal', 'dear', 'decide', 'deep', 'did', 'die', 'do', 'does', 'dog', 'done', 'doubt', 'down', 'during', 'each', 'ear', 'early', 'eat', 'effort', 'either', 'else', 'end', 'enjoy', 'enough', 'enter', 'even', 'ever', 'every', 'except', 'expect', 'explain', 'fail', 'fall', 'far', 'fat', 'favor', 'fear', 'feel', 'feet', 'fell', 'felt', 'few', 'fill', 'find', 'fit', 'fly', 'follow', 'for', 'forever', 'forget', 'from', 'front', 'gave', 'get', 'gives', 'goes', 'gone', 'good', 'got', 'gray', 'great', 'green', 'grew', 'grow', 'guess', 'had', 'half', 'hang', 'happen', 'has', 'hat', 'have', 'he', 'hear', 'heard', 'held', 'hello', 'help', 'her', 'here', 'hers', 'high', 'hill', 'him', 'his', 'hit', 'hold', 'hot', 'how', 'however', 'I', 'if', 'ill', 'in', 'indeed', 'instead', 'into', 'iron', 'is', 'it', 'its', 'just', 'keep', 'kept', 'knew', 'know', 'known', 'late', 'least', 'led', 'left', 'lend', 'less', 'let', 'like', 'likely', 'likr', 'lone', 'long', 'look', 'lot', 'make', 'many', 'may', 'me', 'mean', 'met', 'might', 'mile', 'mine', 'moon', 'more', 'most', 'move', 'much', 'must', 'my', 'near', 'nearly', 'necessary', 'neither', 'never', 'next', 'no', 'none', 'nor', 'not', 'note', 'nothing', 'now', 'number', 'of', 'off', 'often', 'oh', 'on', 'once', 'only', 'or', 'other', 'ought', 'our', 'out', 'please', 'prepare', 'probable', 'pull', 'pure', 'push', 'put', 'raise', 'ran', 'rather', 'reach', 'realize', 'reply', 'require', 'rest', 'run', 'said', 'same', 'sat', 'saw', 'say', 'see', 'seem', 'seen', 'self', 'sell', 'sent', 'separate', 'set', 'shall', 'she', 'should', 'side', 'sign', 'since', 'so', 'sold', 'some', 'soon', 'sorry', 'stay', 'step', 'stick', 'still', 'stood', 'such', 'sudden', 'suppose', 'take', 'taken', 'talk', 'tall', 'tell', 'ten', 'than', 'thank', 'that', 'the', 'their', 'them', 'then', 'there', 'therefore', 'these', 'they', 'this', 'those', 'though', 'through', 'till', 'to', 'today', 'told', 'tomorrow', 'too', 'took', 'tore', 'tought', 'toward', 'tried', 'tries', 'trust', 'try', 'turn', 'two', 'under', 'until', 'up', 'upon', 'us', 'use', 'usual', 'various', 'verb', 'very', 'visit', 'want', 'was', 'we', 'well', 'went', 'were', 'what', 'when', 'where', 'whether', 'which', 'while', 'white', 'who', 'whom', 'whose', 'why', 'will', 'with', 'within', 'without', 'would', 'yes', 'yet', 'you', 'young', 'your'];
@@ -16,6 +16,8 @@ function extract(content) {
   // 10. remove stop words
   // 11. get words
   // 12. return only 10 words
+
+  config = config || {};
 
   return content
     .toLowerCase()
@@ -40,7 +42,7 @@ function extract(content) {
     }, [])
     .sort(function (x, y) { return y.ct - x.ct; })
     .filter(function (v) {
-      return v.kw.length > 3;
+      return v.kw.length > config.minWordLength ? config.minWordLength : 3;
     })
     .filter(function (v) {
       return stops.indexOf(v.kw) === -1;
@@ -48,7 +50,7 @@ function extract(content) {
     .map(function (v) {
       return v.kw;
     })
-    .slice(0, 10);
+    .slice(0, config.maxNumOfKeywords ? config.maxNumOfKeywords : 10);
 }
 
 exports = module.exports = extract;


### PR DESCRIPTION
Created an optional "config" object to pass two parameters:

```
var keywords = extract('your text here', { minWordLength : 2, maxNumOfKeywords: 20 });
```
